### PR TITLE
Bump sinon-chrome version

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var pattern = function(file) {
 
 var framework = function(files) {
   var sinonPath = path.resolve(require.resolve('sinon'), '../../pkg/sinon.js');
-  var sinonChromePath = path.resolve(require.resolve('sinon-chrome'), '../../chrome.js');
+  var sinonChromePath = path.resolve(require.resolve('sinon-chrome'), '../../dist/sinon-chrome.latest.js');
   files.unshift(pattern(sinonChromePath));
   files.unshift(pattern(sinonPath));
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "9joneg",
   "dependencies": {
     "sinon": "^1.17.1",
-    "sinon-chrome": "^0.2.1"
+    "sinon-chrome": "^1.1.2"
   },
   "keywords": [
     "karma-plugin",


### PR DESCRIPTION
A lot of [changes](https://github.com/acvetkov/sinon-chrome/releases) have happened since sinon-chai `0.2.1`.

Bumped the sinon-chai dependency to gain access to the new features.
