### PR TITLE
Update sinon-chrome version.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var pattern = function (file) {
 }
 
 var framework = function (files) {
-  var sinonChromePath = path.resolve(require.resolve('sinon-chrome'), '../../dist/sinon-chrome.latest.js')
+  var sinonChromePath = path.resolve(require.resolve('sinon-chrome'), '../../sinon-chrome/bundle/sinon-chrome.min.js')
   files.unshift(pattern(sinonChromePath))
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.2.0",
   "author": "9joneg",
   "dependencies": {
-    "sinon-chrome": "^1.1.2"
+    "sinon-chrome": "^2.2.1"
   },
   "devDependencies": {
     "di": "0.0.1",


### PR DESCRIPTION
The Firefox/browser/WebExtension API is only available since sinon-chrome version 2.1.0 or later.  Update the dependency to the latest sinon-chrome version.

There will probably be other changes necessary, but this is a clear first step.  See also: https://github.com/acvetkov/sinon-chrome/issues/68